### PR TITLE
Deserialize xml key value pairs

### DIFF
--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -151,6 +151,28 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
 
     public function visitArray($data, array $type, Context $context)
     {
+        $metadata = $this->currentMetadata;
+        if (null === $metadata && $context->getMetadataStack()->count()) {
+            $metadata = $context->getMetadataStack()->top();
+        }
+
+        // handle key-value-pairs
+        if (null !== $metadata && $metadata->xmlKeyValuePairs) {
+            if (2 !== count($type['params'])) {
+                throw new RuntimeException(sprintf('The array type must be specified as "array<K,V>" for Key-Value-Pairs.'));
+            }
+
+            list($keyType, $entryType) = $type['params'];
+
+            $result = [];
+            foreach ($data as $key => $v) {
+                $k = $this->navigator->accept($key, $keyType, $context);
+                $result[$k] = $this->navigator->accept($v, $entryType, $context);
+            }
+
+            return $result;
+        }
+
         $entryName = null !== $this->currentMetadata && $this->currentMetadata->xmlEntryName ? $this->currentMetadata->xmlEntryName : 'entry';
         $namespace = null !== $this->currentMetadata && $this->currentMetadata->xmlEntryNamespace ? $this->currentMetadata->xmlEntryNamespace : null;
 

--- a/src/JMS/Serializer/XmlDeserializationVisitor.php
+++ b/src/JMS/Serializer/XmlDeserializationVisitor.php
@@ -151,13 +151,8 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
 
     public function visitArray($data, array $type, Context $context)
     {
-        $metadata = $this->currentMetadata;
-        if (null === $metadata && $context->getMetadataStack()->count()) {
-            $metadata = $context->getMetadataStack()->top();
-        }
-
         // handle key-value-pairs
-        if (null !== $metadata && $metadata->xmlKeyValuePairs) {
+        if ($this->currentMetadata !== null && $this->currentMetadata->xmlKeyValuePairs) {
             if (2 !== count($type['params'])) {
                 throw new RuntimeException(sprintf('The array type must be specified as "array<K,V>" for Key-Value-Pairs.'));
             }
@@ -290,6 +285,10 @@ class XmlDeserializationVisitor extends AbstractVisitor implements NullAwareVisi
             $this->accessor->setValue($this->currentObject, $v, $metadata);
 
             return;
+        }
+
+        if ($metadata->xmlKeyValuePairs) {
+            $this->setCurrentMetadata($metadata);
         }
 
         if ($metadata->xmlNamespace) {

--- a/tests/Fixtures/ObjectWithXmlKeyValuePairsWithSameValueTypes.php
+++ b/tests/Fixtures/ObjectWithXmlKeyValuePairsWithSameValueTypes.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2016 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace JMS\Serializer\Tests\Fixtures;
+
+use JMS\Serializer\Annotation\Type;
+use JMS\Serializer\Annotation\XmlKeyValuePairs;
+
+class ObjectWithXmlKeyValuePairsWithSameValueTypes
+{
+    /**
+     * @var array
+     * @Type("array<string,string>")
+     * @XmlKeyValuePairs
+     */
+    private $list = array(
+        'key-one' => 'foo',
+        'key-two' => 'bar',
+    );
+}

--- a/tests/Serializer/XmlSerializationTest.php
+++ b/tests/Serializer/XmlSerializationTest.php
@@ -42,6 +42,7 @@ use JMS\Serializer\Tests\Fixtures\ObjectWithNamespacesAndList;
 use JMS\Serializer\Tests\Fixtures\ObjectWithToString;
 use JMS\Serializer\Tests\Fixtures\ObjectWithVirtualXmlProperties;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairs;
+use JMS\Serializer\Tests\Fixtures\ObjectWithXmlKeyValuePairsWithSameValueTypes;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespaces;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespacesAndObjectProperty;
 use JMS\Serializer\Tests\Fixtures\ObjectWithXmlNamespacesAndObjectPropertyAuthor;
@@ -247,6 +248,13 @@ class XmlSerializationTest extends BaseSerializationTest
     public function testArrayKeyValues()
     {
         $this->assertEquals($this->getContent('array_key_values'), $this->serializer->serialize(new ObjectWithXmlKeyValuePairs(), 'xml'));
+    }
+
+    public function testDeserializeArrayKeyValues()
+    {
+        $xml = $this->getContent('array_key_values_with_same_value_types');
+        $result = $this->serializer->deserialize($xml, ObjectWithXmlKeyValuePairsWithSameValueTypes::class, 'xml');
+        $this->assertEquals(new ObjectWithXmlKeyValuePairsWithSameValueTypes(), $result);
     }
 
     /**

--- a/tests/Serializer/xml/array_key_values_with_same_value_types.xml
+++ b/tests/Serializer/xml/array_key_values_with_same_value_types.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <list>
+    <key-one><![CDATA[foo]]></key-one>
+    <key-two><![CDATA[bar]]></key-two>
+  </list>
+</result>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| Doc updated   | yes/no
| BC breaks?    | yes/no <!-- don't forget updating UPGRADING.md file -->
| Deprecations? | yes/no <!-- don't forget updating UPGRADING.md file -->
| Tests pass?   | yes/no
| Fixed tickets | #820 schmittjoh/JMSSerializerBundle#521 schmittjoh/JMSSerializerBundle#470 #840
| License       | Apache-2.0

This is an updated version of #840. 

Allows to de serialize xml arrays with tag names as keys.

This version has a cleaner implementation and supports nested key-value objects 

